### PR TITLE
Temporarily disable remote cache in CI

### DIFF
--- a/pants.ci.toml
+++ b/pants.ci.toml
@@ -12,5 +12,7 @@ pants_ignore = [
   ".cache/pants/lmdb_store",
 ]
 
-[auth]
-from_env_var = "TOOLCHAIN_AUTH_TOKEN"
+# Temporarily disable the remote cache until we can get
+# repository-specific tokens into the CI/CD system
+# [auth]
+# from_env_var = "TOOLCHAIN_AUTH_TOKEN"


### PR DESCRIPTION
Our system isn't really set up for getting repository-specific tokens
into place at the moment, and this is causing issues on Toolchain's
end, so until we get it sorted out, we'll just temporarily disable the
remote cache.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>