### PR TITLE
Enable AWS metadata checks for Pulumi runs

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -53,6 +53,22 @@ pulumi login
 project="$(project_name "${project_dir}" "${stack}")"
 readonly project
 
+# The default for this is `true`, which was set to reduce unnecessary
+# network calls, but is actually useful to have in AWS! This lets us
+# get credentials from the IMDS.
+#
+# While it *technically* means that our configuration is not precisely
+# what is in version control, it's a configuration that doesn't
+# actually have any impact on the infrastructure being created.
+#
+# For further background, see:
+# https://github.com/pulumi/pulumi-aws/pull/1288
+# https://github.com/pulumi/pulumi-aws/issues/1636
+pulumi config set \
+    aws:skipMetadataApiCheck false \
+    --cwd="${project_dir}" \
+    --stack="${stack}"
+
 case "${command}" in
     preview)
         echo -e "--- :pulumi: Previewing changes to ${project} + ${stack} infrastructure"

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -23,6 +23,7 @@ teardown() {
     stub pulumi \
          "login : echo 'Logging in to Pulumi SaaS'" \
          "stack export --cwd=pulumi/my-project --stack=my-org/my-stack : echo '{\"deployment\": {\"secrets_providers\": {\"state\": {\"project\": \"my-project\"}}}}'" \
+         "config set aws:skipMetadataApiCheck false --cwd=pulumi/my-project --stack=my-org/my-stack : echo 'enabling metadataApiCheck'" \
          "preview --cwd=pulumi/my-project --stack=my-org/my-stack --show-replacement-steps --non-interactive --diff --message=\"Previewing from https://buildkite.com/my-org/my-pipeline/builds/1\" : echo 'Doing a Pulumi preview'"
 
     stub pants_venv_setup \
@@ -44,6 +45,7 @@ teardown() {
     stub pulumi \
          "login : echo 'Logging in to Pulumi SaaS'" \
          "stack export --cwd=pulumi/my-project --stack=my-org/my-stack : echo '{\"deployment\": {\"secrets_providers\": {\"state\": {\"project\": \"my-project\"}}}}'" \
+         "config set aws:skipMetadataApiCheck false --cwd=pulumi/my-project --stack=my-org/my-stack : echo 'enabling metadataApiCheck'" \
          "update --cwd=pulumi/my-project --stack=my-org/my-stack --show-replacement-steps --non-interactive --diff --yes --message=\"Updating from https://buildkite.com/my-org/my-pipeline/builds/1\" : echo 'Doing a Pulumi update'"
 
     stub pants_venv_setup \


### PR DESCRIPTION
This modification allows Pulumi to pull credentials from the instance
metadata service. This, in turn, will allow us to remove workarounds
to expose credentials to Pulumi in other repositories.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>