### PR TITLE
Remove CI-specific Pants cache information

### DIFF
--- a/pants.ci.toml
+++ b/pants.ci.toml
@@ -2,15 +2,5 @@
 dynamic_ui = false
 colors = true
 
-# Since multiple jobs could run on the same Buildkite worker node, we
-# need to make sure the cache directories are isolated.
-local_store_dir = ".cache/pants/lmdb_store"
-named_caches_dir = ".cache/pants/named_caches"
-
-pants_ignore = [
-  ".cache/pants/named_caches",
-  ".cache/pants/lmdb_store",
-]
-
 [auth]
 from_env_var = "TOOLCHAIN_AUTH_TOKEN"


### PR DESCRIPTION
This was a holdover from a prior caching strategy. Now that we use
Toolchain Labs' remote caching service, we can remove this.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>