### PR TITLE
Update and lock Buildkite images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+DOCKER_COMPOSE_CHECK := docker compose run --rm
+
 .PHONY: all
 all: format
 all: lint
@@ -17,7 +19,7 @@ lint-docker:  ## Lint Dockerfiles
 
 .PHONY: lint-plugin
 lint-plugin:
-	docker-compose run --rm plugin-linter
+	$(DOCKER_COMPOSE_CHECK) plugin-linter
 
 .PHONY: lint-shell
 lint-shell:
@@ -42,7 +44,7 @@ test: test-shell
 
 .PHONY: test-plugin
 test-plugin:
-	docker-compose build && docker-compose run --rm plugin-tester
+	docker compose build && $(DOCKER_COMPOSE_CHECK) plugin-tester
 
 .PHONY: test-shell
 test-shell:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 x-common-variables:
   read-only-workdir: &read-only-workdir
     type: bind

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - *read-only-plugin
 
   plugin-linter:
-    image: buildkite/plugin-linter:latest # the only available tag
+    image: buildkite/plugin-linter@sha256:833b1ce8326b038c748c8f04d317045205e115b1732a6842ec4a957f550fe357
     command: ["--id", "grapl-security/pulumi"]
     volumes:
       - *read-only-plugin

--- a/plugin-tester.Dockerfile
+++ b/plugin-tester.Dockerfile
@@ -1,7 +1,6 @@
-# latest, as of 2022-05-17
-FROM buildkite/plugin-tester@sha256:476a1024936901889147f53d2a3d8e71e99d76404972d583825514f5608083dc
+FROM buildkite/plugin-tester:v2.0.0
 
 # Install a real version of `realpath` which respects the
 # `--relative-to` option. (The `busybox` version built into the
 # upstream `buildkite/plugin-tester` image does not).
-RUN apk add --no-cache coreutils=8.29-r2
+RUN apk add --no-cache coreutils=9.0-r2

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-load "$BATS_PATH/load.bash"
+load "$BATS_PLUGIN_PATH/load.bash"
 
 # Uncomment to enable stub debugging
 # export PULUMI_STUB_DEBUG=/dev/tty


### PR DESCRIPTION
There's an official release for [`buildkite/plugin-tester`](https://github.com/buildkite-plugins/buildkite-plugin-tester/releases/tag/v2.0.0) now. It updates several bits of BATS infrastructure, but also introduces a breaking change.

This PR locks us to the `v2.0.0` release of the `plugin-tester` image, and addresses the breaking change.

I also noticed that our use of the `buildkite/plugin-linter` image was also pinned to `latest`, just as our `buildkite/plugin-tester` image was. There are no formal release of this image (yet :crossed_fingers:), so I've pinned it to a concrete SHA to be safe.

While making these fixes, I also took the liberty of shifting our Docker Compose usage explicitly to v2, as we have been doing across all our projects lately.