### PR TITLE
Update `vault-login` Buildkite plugin to `v0.1.3`

### DIFF
--- a/.buildkite/pipeline.verify.yml
+++ b/.buildkite/pipeline.verify.yml
@@ -12,7 +12,7 @@ steps:
     command:
       - make lint-shell
     plugins:
-      - grapl-security/vault-login#v0.1.2
+      - grapl-security/vault-login#v0.1.3
       - grapl-security/vault-env#v0.1.0:
           secrets:
             - pulumi-buildkite-plugin/TOOLCHAIN_AUTH_TOKEN
@@ -25,7 +25,7 @@ steps:
     command:
       - make test-shell
     plugins:
-      - grapl-security/vault-login#v0.1.2
+      - grapl-security/vault-login#v0.1.3
       - grapl-security/vault-env#v0.1.0:
           secrets:
             - pulumi-buildkite-plugin/TOOLCHAIN_AUTH_TOKEN
@@ -38,7 +38,7 @@ steps:
 
   - label: ":buildkite::pulumi: Run Plugin - Preview"
     plugins:
-      - grapl-security/vault-login#v0.1.2
+      - grapl-security/vault-login#v0.1.3
       - grapl-security/vault-env#v0.1.0:
           secrets:
             - PULUMI_ACCESS_TOKEN
@@ -53,7 +53,7 @@ steps:
 
   - label: ":buildkite::pulumi: Run Plugin - Preview - with no refresh"
     plugins:
-      - grapl-security/vault-login#v0.1.2
+      - grapl-security/vault-login#v0.1.3
       - grapl-security/vault-env#v0.1.0:
           secrets:
             - PULUMI_ACCESS_TOKEN
@@ -70,7 +70,7 @@ steps:
 
   - label: ":buildkite::pulumi: Run Plugin - Update"
     plugins:
-      - grapl-security/vault-login#v0.1.2
+      - grapl-security/vault-login#v0.1.3
       - grapl-security/vault-env#v0.1.0:
           secrets:
             - PULUMI_ACCESS_TOKEN


### PR DESCRIPTION
Update grapl-security/vault-login Buildkite plugin version to v0.1.3

Picks up additional logging features, specifically https://github.com/grapl-security/vault-login-buildkite-plugin/pull/26

---

*This change was executed automatically with [Shepherd](https://github.com/NerdWalletOSS/shepherd).* 💚🤖