### PR TITLE
Update `buildkite/plugin-tester` to v3.0.1

### DIFF
--- a/plugin-tester.Dockerfile
+++ b/plugin-tester.Dockerfile
@@ -1,4 +1,4 @@
-FROM buildkite/plugin-tester:v2.0.0
+FROM buildkite/plugin-tester:v3.0.1
 
 # Install a real version of `realpath` which respects the
 # `--relative-to` option. (The `busybox` version built into the


### PR DESCRIPTION
This would have been v3.0.0, but there was a bug in that version that
this test suite triggered.

- https://github.com/buildkite-plugins/buildkite-plugin-tester/releases/tag/v3.0.1
- https://github.com/buildkite-plugins/bats-mock/pull/8

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
